### PR TITLE
Fixed Bug (assumed) legacy naming of package as "pymerge" to "dictmerge"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,17 @@
 # [ -Python- ]
 from setuptools import setup
 # [ -Project- ]
-import pymerge
+import dictmerge
 
 
 # [ Main ]
 setup(
-    name='pymerge',
+    name='dictmerge',
     version='0.4.3',
-    packages=['pymerge'],
-    description=pymerge.__doc__,
+    packages=['dictmerge'],
+    description=dictmerge.__doc__,
     author='toejough',
-    url='https://github.com/toejough/pymerge',
+    url='https://github.com/toejough/dictmerge',
     license='MIT'
 )
 

--- a/test_main.py
+++ b/test_main.py
@@ -1,4 +1,4 @@
-'''Tests for pymerge'''
+'''Tests for dictmerge'''
 
 
 # [ Imports ]


### PR DESCRIPTION
Package installation failed with "pymerge" because of import errors...replaced with "dictmerge", installed, and worked. :)